### PR TITLE
Add KOHEB as an TA block-week counting as Zusatzmodul

### DIFF
--- a/data/modules_i.json
+++ b/data/modules_i.json
@@ -80,6 +80,7 @@
     "IoT": "Majormodul",
     "KBDS": "Majormodul",
     "KKM": "Zusatzmodul",
+    "KOHEB": "Zusatzmodul",
     "KUFA": "Zusatzmodul",
     "LINALG": "Erweiterungsmodul",
     "MA+PHY1_T": "Erweiterungsmodul",

--- a/tools/parse_module_type.py
+++ b/tools/parse_module_type.py
@@ -71,6 +71,7 @@ def parseWebsite():
     modules_with_type['OEK_PWG'] = zusatzmodul
     modules_with_type['ME+TE'] = zusatzmodul
     modules_with_type['WEBLAB'] = majormodul
+    modules_with_type['KOHEB'] = zusatzmodul
 
     # Other modules (that don't appear on the website)
     modules_with_type['XML'] = erweiterungsmodul


### PR DESCRIPTION
KOHEB is the block-week "Handeln, Handeln, Vermitteln" done by TA department.

Currently the module "KOHEB" is shown as undefined when I add your extension.
Happy to allow any edits you may need to do on this PR.
Thanks for the great extension.