### PR TITLE
Add correct permissions to fix API fetch error (#16)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,11 @@
       }
     ],
 
+    "permissions": [
+      "https://mycampus.hslu.ch/*",
+      "webRequest"
+    ],
+
     "web_accessible_resources": [
       "templates/grades_table.html",
       "templates/credits_by_module_type_table.html",


### PR DESCRIPTION
The session cookies of the mycampus page have the attribute "sameSite=Lax",
which is the reason they are not included in normal browser extension
requests and the API request will fail (as there is no session active).