### PR TITLE
Add tweaks to ignore strange module names

### DIFF
--- a/src/components/module_parser.js
+++ b/src/components/module_parser.js
@@ -34,8 +34,9 @@ const ModuleParser = {
      * or 'F' for 'Frühlingssemester' (spring).
      */
     isAutumnSemester: (hsluModuleName) => {
-        const includesH = hsluModuleName.split('.')[2].includes('H');
-        const includesF = hsluModuleName.split('.')[2].includes('F');
+        let split_name = hsluModuleName.split('.')[2]
+        const includesH = split_name ? split_name.includes('H') : false;
+        const includesF = split_name ? split_name.includes('F') : false;
         return includesH || includesF ? includesH : undefined;
     },
 

--- a/src/components/module_parser.js
+++ b/src/components/module_parser.js
@@ -51,7 +51,7 @@ const ModuleParser = {
         const isStartInAutumn = ModuleParser.isAutumnSemester(firstModule.anlassnumber);
 
         const lastPart = hsluModuleName.split('.')[2];
-        const moduleYear = Number('20' + lastPart.substring(1, 3));
+        const moduleYear = Number('20' + (lastPart != undefined ? lastPart.substring(1, 3) : '00'));
         const isModuleInAutumn = ModuleParser.isAutumnSemester(hsluModuleName);
 
         const yearDifference = (moduleYear - startYear)


### PR DESCRIPTION
I have some strangely named modules in my module registrations like "I.WS3_GAME_DS" which results in errors thrown, since it is assumed that every module has a year and a semester (F/H). These tweaks fix it.