### PR TITLE
Get the credits from the new ects field

### DIFF
--- a/src/components/module_parser.js
+++ b/src/components/module_parser.js
@@ -12,23 +12,6 @@ const updateModuleTypeList = async (oldModuleTypeList, jsonFilePath) => {
 const ModuleParser = {
 
     /**
-    * Gets the value ("y") of a specified key ("x") in a 'detail' element of the API response.
-    * detail: [
-    *   key: "x",
-    *   val: "y"
-    * ]
-    */
-    getItemDetailsValueByKey: (details, key) => {
-
-        for (detail of details) {
-            if (key == detail.key) {
-                return detail.val;
-            }
-        }
-        return '';
-    },
-
-    /**
      * Check if a module was done in Autumn.
      * Modules are marked with 'H' for 'Herbstsemester' (autumn)
      * or 'F' for 'Frühlingssemester' (spring).


### PR DESCRIPTION
Get json from the module "api" changed again. Until now the credits for each module were under module.details.etcs-credits. New they are directly under the module object. 