### PR TITLE
added ignore module pattern to calculate the first semester, solves #95

### DIFF
--- a/src/components/module_parser.js
+++ b/src/components/module_parser.js
@@ -9,8 +9,6 @@ const updateModuleTypeList = async (oldModuleTypeList, jsonFilePath) => {
     return Object.assign(oldModuleTypeList, patch);
 }
 
-
-
 const ModuleParser = {
 
     /**

--- a/src/components/module_parser.js
+++ b/src/components/module_parser.js
@@ -9,6 +9,8 @@ const updateModuleTypeList = async (oldModuleTypeList, jsonFilePath) => {
     return Object.assign(oldModuleTypeList, patch);
 }
 
+
+
 const ModuleParser = {
 
     /**
@@ -130,6 +132,22 @@ const ModuleParser = {
         return false
     },
     /**
+     *  list of modules that should be ignored to calculate the first semester
+     *  check if moduleName matches ignore pattern
+     */
+    shouldModuleBeIgnored: (hsluModuleName) => {
+        const ignoreModulePatterns = ['INFO_ABEND'];
+        let dontIgnore = true;
+        ignoreModulePatterns.forEach(ignorePattern => {
+            if(hsluModuleName.includes(ignorePattern)) {
+                console.log(`ignoring module ${hsluModuleName} for first semester calculation`)
+                dontIgnore = false;
+            }
+        })
+
+        return dontIgnore;
+    },
+    /**
     * Generates an array of module objects using the API and the module type mapping json file.
     */
     generateModuleObjects: async (studyAcronym) => {
@@ -157,6 +175,8 @@ const ModuleParser = {
         firstModule = anlasslistApiResponse.items
             .slice()
             .reverse()
+            //check if module is is in the ignore list
+            .filter(modul => ModuleParser.shouldModuleBeIgnored(modul.anlassnumber))
             .find(modul => ModuleParser.isAutumnSemester(modul.anlassnumber) != undefined);
 
         const passedMessage = await i18n.getMessage("Bestanden");
@@ -202,7 +222,7 @@ const ModuleParser = {
             // sets the UseInStats to true by default
             parsedModule.UseInStats = true;
             if (ignoreInStatsModules != undefined && ignoreInStatsModules[parsedModule.name]) {
-                    parsedModule.UseInStats = false;
+                parsedModule.UseInStats = false;
             }
             myCampusModulesList[parsedModule.name] = {
                 acronym: parsedModule.name,


### PR DESCRIPTION
I added a new static list of module name patterns that should be ignored on the first semester calculation.
These are only ignored on the `firstModule` calculation.
This solves the issue #95.

If you want another solution I'm open to it. 
Maybe we should also ignore modules that are in `ignoreInStatsModules`. 